### PR TITLE
(bugfix) possible stale memory usage when (de)serializing yaml map bi…

### DIFF
--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -133,6 +133,16 @@ namespace CrossPlatform
 	std::string getExeFilename(bool includingPath);
 	/// Starts the update process.
 	void startUpdateProcess();
+
+	// in Release, do nothing. in Debug, crash out
+	[[noreturn]] inline void unreachable()
+	{
+	#ifdef _WIN32 // MSVC
+	    __assume(false);
+	#else  // GCC, Clang
+		__builtin_unreachable();
+	#endif
+	}
 }
 
 }

--- a/src/Savegame/SerializationHelper.cpp
+++ b/src/Savegame/SerializationHelper.cpp
@@ -21,6 +21,9 @@
 #include <sstream>
 #include <cfloat>
 
+#include "../Engine/Logger.h"
+#include "../Engine/CrossPlatform.h"
+
 namespace OpenXcom
 {
 
@@ -35,7 +38,9 @@ int unserializeInt(Uint8 **buffer, Uint8 sizeKey)
 	switch(sizeKey)
 	{
 	case 1:
-		ret = **buffer;
+		Uint8 tmp;
+		memcpy(&tmp, *buffer, sizeof(tmp));
+		ret = tmp;
 		break;
 	case 2:
 	{
@@ -44,9 +49,6 @@ int unserializeInt(Uint8 **buffer, Uint8 sizeKey)
 		ret = tmp;
 		break;
 	}
-	case 3:
-		assert(false); // no.
-		break;
 	case 4:
 	{
 		Uint32 tmp;
@@ -55,7 +57,16 @@ int unserializeInt(Uint8 **buffer, Uint8 sizeKey)
 		break;
 	}
 	default:
-		assert(false); // get out.
+	{
+		// XXX: if this unreachable block gets hit, check to see
+		//   that sizeKey is being properly initialized
+		#ifdef NDEBUG
+			Log(LOG_WARNING) << "unserializeInt has invalid sizeKey of " << sizeKey
+				<< " .. this can mean deserialization data is ill-formed";
+		#else
+			CrossPlatform::unreachable();
+		#endif
+	}
 	}
 
 	*buffer += sizeKey;
@@ -73,9 +84,12 @@ void serializeInt(Uint8 **buffer, Uint8 sizeKey, int value)
 	switch(sizeKey)
 	{
 	case 1:
+	{
+		Uint8 u8Value = value;
 		assert(value < 256);
-		**buffer = value;
+		memcpy(*buffer, &u8Value, sizeof(Uint8));
 		break;
+	}
 	case 2:
 	{
 		Sint16 s16Value = value;
@@ -83,9 +97,6 @@ void serializeInt(Uint8 **buffer, Uint8 sizeKey, int value)
 		memcpy(*buffer, &s16Value, sizeof(Sint16));
 		break;
 	}
-	case 3:
-		assert(false); // no.
-		break;
 	case 4:
 	{
 		Uint32 u32Value = value;
@@ -93,7 +104,16 @@ void serializeInt(Uint8 **buffer, Uint8 sizeKey, int value)
 		break;
 	}
 	default:
-		assert(false); // get out.
+	{
+		// XXX: if this unreachable block gets hit, check to see
+		//   that sizeKey is being properly initialized
+		#ifdef NDEBUG
+			Log(LOG_WARNING) << "serializeInt has invalid sizeKey of " << sizeKey
+				<< " .. this can mean serialization data is ill-formed";
+		#else
+			CrossPlatform::unreachable();
+		#endif
+	}
 	}
 
 	*buffer += sizeKey;

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -60,9 +60,9 @@ public:
 	/// Register all useful function used by script.
 	static void ScriptRegister(ScriptParserBase* parser);
 
-	static struct SerializationKey
+	typedef struct SerializationKey
 	{
-		// how many bytes to store for each variable or each member of array of the same name
+
 		Uint8 index; // for indexing the actual tile array
 		Uint8 _mapDataSetID;
 		Uint8 _mapDataID;
@@ -73,7 +73,9 @@ public:
 		Uint16 _lastExploredByNeutral;
 		Uint16 _lastExploredByPlayer;
 		Uint32 totalBytes; // per structure, including any data not mentioned here and accounting for all array members!
-	} serializationKey;
+
+		static const SerializationKey defaultKey();
+	} SerializationKey;
 
 	static const int NOT_CALCULATED = -1;
 


### PR DESCRIPTION
…ndata

  1. Fix for uninitialized memory / undefined behavior crash, stemming from 'lastExploredBy(x)' fields in SerializationKey not being propagated to savegames
  2. minor refactoring of 'Tile::SerializationKey', to make more explicit when defaults for a key are being used
