### PR TITLE
Right align numbers in lists

### DIFF
--- a/src/Basescape/CraftEquipmentState.cpp
+++ b/src/Basescape/CraftEquipmentState.cpp
@@ -191,7 +191,10 @@ CraftEquipmentState::CraftEquipmentState(Base *base, size_t craft) :
 	_cbxFilterBy->onChange((ActionHandler)&CraftEquipmentState::cbxFilterByChange);
 
 	_lstEquipment->setArrowColumn(203, ARROW_HORIZONTAL);
-	_lstEquipment->setColumns(3, 156, 83, 41);
+//	_lstEquipment->setColumns(3, 156, 83, 41);
+	_lstEquipment->setColumns(3, 140, 50, 50, 40);
+	_lstEquipment->setAlign(ALIGN_RIGHT, 1);
+	_lstEquipment->setAlign(ALIGN_RIGHT, 2);
 	_lstEquipment->setSelectable(true);
 	_lstEquipment->setBackground(_window);
 	_lstEquipment->setMargin(8);

--- a/src/Basescape/GlobalResearchState.cpp
+++ b/src/Basescape/GlobalResearchState.cpp
@@ -88,7 +88,9 @@ GlobalResearchState::GlobalResearchState(bool openedFromBasescape) : _openedFrom
 
 	_txtProgress->setText(tr("STR_PROGRESS"));
 
-	_lstResearch->setColumns(3, 158, 58, 70);
+//	_lstResearch->setColumns(3, 158, 58, 70);
+	_lstResearch->setColumns(4, 148, 20, 40, 98);
+	_lstResearch->setAlign(ALIGN_RIGHT, 1);
 	_lstResearch->setSelectable(true);
 	_lstResearch->setBackground(_window);
 	_lstResearch->setMargin(2);
@@ -180,7 +182,7 @@ void GlobalResearchState::fillProjectList()
 		if (!baseProjects.empty())
 		{
 			std::string baseName = xbase->getName(_game->getLanguage());
-			_lstResearch->addRow(3, baseName.c_str(), "", "");
+			_lstResearch->addRow(4, baseName.c_str(), "", "", "");
 			_lstResearch->setRowColor(_lstResearch->getLastRowIndex(), _lstResearch->getSecondaryColor());
 
 			// dummy
@@ -194,7 +196,7 @@ void GlobalResearchState::fillProjectList()
 			const RuleResearch *r = proj->getRules();
 
 			std::string wstr = tr(r->getName());
-			_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), tr(proj->getResearchProgress()).c_str());
+			_lstResearch->addRow(4, wstr.c_str(), sstr.str().c_str(), "", tr(proj->getResearchProgress()).c_str());
 
 			_bases.push_back(xbase);
 			_topics.push_back(r);

--- a/src/Basescape/MonthlyCostsState.cpp
+++ b/src/Basescape/MonthlyCostsState.cpp
@@ -53,10 +53,10 @@ MonthlyCostsState::MonthlyCostsState(Base *base) : _base(base)
 	_txtSalaries = new Text(150, 9, 10, 80);
 	_txtIncome = new Text(150, 9, 10, 146);
 	_txtMaintenance = new Text(150, 9, 10, 154);
-	_lstCrafts = new TextList(288, 32, 10, 48);
-	_lstSalaries = new TextList(288, 40, 10, 88);
+	_lstCrafts = new TextList(300, 32, 10, 48);
+	_lstSalaries = new TextList(300, 40, 10, 88);
 	_lstMaintenance = new TextList(300, 9, 10, 128);
-	_lstTotal = new TextList(100, 9, 205, 150);
+	_lstTotal = new TextList(105, 9, 205, 150);
 
 	// Set palette
 	setInterface("costsInfo");
@@ -108,7 +108,11 @@ MonthlyCostsState::MonthlyCostsState(Base *base) : _base(base)
 	ss2 << tr("STR_MAINTENANCE") << "=" << Unicode::formatFunding(_game->getSavedGame()->getBaseMaintenance());
 	_txtMaintenance->setText(ss2.str());
 
-	_lstCrafts->setColumns(4, 125, 70, 44, 50);
+//	_lstCrafts->setColumns(4, 125, 70, 44, 50);
+	_lstCrafts->setColumns(4, 115, 50, 50, 85);
+	_lstCrafts->setAlign(ALIGN_RIGHT, 1);
+	_lstCrafts->setAlign(ALIGN_RIGHT, 2);
+	_lstCrafts->setAlign(ALIGN_RIGHT, 3);
 	_lstCrafts->setDot(true);
 
 	for (auto& craftType : _game->getMod()->getCraftsList())
@@ -126,7 +130,11 @@ MonthlyCostsState::MonthlyCostsState(Base *base) : _base(base)
 		}
 	}
 
-	_lstSalaries->setColumns(4, 125, 70, 44, 50);
+//	_lstSalaries->setColumns(4, 125, 70, 44, 50);
+	_lstSalaries->setColumns(4, 115, 50, 50, 85);
+	_lstSalaries->setAlign(ALIGN_RIGHT, 1);
+	_lstSalaries->setAlign(ALIGN_RIGHT, 2);
+	_lstSalaries->setAlign(ALIGN_RIGHT, 3);
 	_lstSalaries->setDot(true);
 
 	auto& soldierTypes = _game->getMod()->getSoldiersList();
@@ -192,13 +200,17 @@ MonthlyCostsState::MonthlyCostsState(Base *base) : _base(base)
 	ss6b << staffCount << "/" << inventoryCount;
 	_lstSalaries->addRow(4, tr("STR_OTHER_EMPLOYEES").c_str(), "", ss6b.str().c_str(), Unicode::formatFunding(totalOtherCost).c_str());
 
-	_lstMaintenance->setColumns(2, 239, 60);
+//	_lstMaintenance->setColumns(2, 239, 60);
+	_lstMaintenance->setColumns(2, 250, 50);
+	_lstMaintenance->setAlign(ALIGN_RIGHT, 1);
 	_lstMaintenance->setDot(true);
 	std::ostringstream ss7;
 	ss7 << Unicode::TOK_COLOR_FLIP << Unicode::formatFunding(_base->getFacilityMaintenance());
 	_lstMaintenance->addRow(2, tr("STR_BASE_MAINTENANCE").c_str(), ss7.str().c_str());
 
-	_lstTotal->setColumns(2, 44, 55);
+//	_lstTotal->setColumns(2, 44, 55);
+	_lstTotal->setColumns(2, 55, 50);
+	_lstTotal->setAlign(ALIGN_RIGHT, 1);
 	_lstTotal->setDot(true);
 	_lstTotal->addRow(2, tr("STR_TOTAL").c_str(), Unicode::formatFunding(_base->getMonthlyMaintenace()).c_str());
 }

--- a/src/Basescape/PurchaseState.cpp
+++ b/src/Basescape/PurchaseState.cpp
@@ -156,7 +156,11 @@ PurchaseState::PurchaseState(Base *base, CannotReequipState *parent) : _base(bas
 	_txtQuantity->setText(tr("STR_QUANTITY_UC"));
 
 	_lstItems->setArrowColumn(227, ARROW_VERTICAL);
-	_lstItems->setColumns(4, 150, 55, 50, 32);
+//	_lstItems->setColumns(4, 150, 55, 50, 32);
+	_lstItems->setColumns(4, 140, 40, 40, 50, 17);
+	_lstItems->setAlign(ALIGN_RIGHT, 1);
+	_lstItems->setAlign(ALIGN_RIGHT, 2);
+	_lstItems->setAlign(ALIGN_RIGHT, 3);
 	_lstItems->setSelectable(true);
 	_lstItems->setBackground(_window);
 	_lstItems->setMargin(2);

--- a/src/Basescape/ResearchState.cpp
+++ b/src/Basescape/ResearchState.cpp
@@ -100,7 +100,9 @@ ResearchState::ResearchState(Base *base) : _base(base)
 
 	_txtProgress->setText(tr("STR_PROGRESS"));
 
-	_lstResearch->setColumns(3, 158, 58, 70);
+//	_lstResearch->setColumns(3, 158, 58, 70);
+	_lstResearch->setColumns(4, 148, 20, 40, 98);
+	_lstResearch->setAlign(ALIGN_RIGHT, 1);
 	_lstResearch->setSelectable(true);
 	_lstResearch->setBackground(_window);
 	_lstResearch->setMargin(2);
@@ -238,7 +240,7 @@ void ResearchState::fillProjectList(size_t scrl)
 		const RuleResearch *r = proj->getRules();
 
 		std::string wstr = tr(r->getName());
-		_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), tr(proj->getResearchProgress()).c_str());
+		_lstResearch->addRow(4, wstr.c_str(), sstr.str().c_str(), "", tr(proj->getResearchProgress()).c_str());
 	}
 	_txtAvailable->setText(tr("STR_SCIENTISTS_AVAILABLE").arg(_base->getAvailableScientists()));
 	_txtAllocated->setText(tr("STR_SCIENTISTS_ALLOCATED").arg(_base->getAllocatedScientists()));

--- a/src/Basescape/SellState.cpp
+++ b/src/Basescape/SellState.cpp
@@ -164,7 +164,11 @@ void SellState::delayedInit()
 	_txtValue->setText(tr("STR_VALUE"));
 
 	_lstItems->setArrowColumn(182, ARROW_VERTICAL);
-	_lstItems->setColumns(4, 156, 54, 24, 53);
+//	_lstItems->setColumns(4, 156, 54, 24, 53);
+	_lstItems->setColumns(4, 147, 25, 60, 50, 5);
+	_lstItems->setAlign(ALIGN_RIGHT, 1);
+	_lstItems->setAlign(ALIGN_RIGHT, 2);
+	_lstItems->setAlign(ALIGN_RIGHT, 3);
 	_lstItems->setSelectable(true);
 	_lstItems->setBackground(_window);
 	_lstItems->setMargin(2);

--- a/src/Basescape/StoresState.cpp
+++ b/src/Basescape/StoresState.cpp
@@ -176,7 +176,11 @@ StoresState::StoresState(Base *base) : _base(base)
 	_txtSize->setText(tr("STR_SIZE_UC"));
 	_txtSpaceUsed->setText(tr("STR_SPACE_USED_UC"));
 
-	_lstStores->setColumns(4, 162, 40, 50, 34);
+//	_lstStores->setColumns(4, 162, 40, 50, 34);
+	_lstStores->setColumns(4, 162, 20, 40, 64);
+	_lstStores->setAlign(ALIGN_RIGHT, 1);
+	_lstStores->setAlign(ALIGN_RIGHT, 2);
+	_lstStores->setAlign(ALIGN_RIGHT, 3);
 	_lstStores->setSelectable(true);
 	_lstStores->setBackground(_window);
 	_lstStores->setMargin(2);
@@ -463,8 +467,8 @@ void StoresState::updateList()
 	{
 		std::ostringstream ss, ss2, ss3;
 		ss << item.quantity;
-		ss2 << item.size;
-		ss3 << item.spaceUsed;
+		ss2 << ((int)floor(item.size)) << "." << ((int)floor((item.size - floor(item.size)) * 10)) << ((int)floor((item.size * 10 - floor(item.size * 10)) * 10));
+		ss3 << ((int)floor(item.spaceUsed)) << "." << ((int)floor((item.spaceUsed - floor(item.spaceUsed)) * 10)) << ((int)floor((item.spaceUsed * 10 - floor(item.spaceUsed * 10)) * 10));
 		_lstStores->addRow(4, item.name.c_str(), ss.str().c_str(), ss2.str().c_str(), ss3.str().c_str());
 	}
 }

--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -118,7 +118,11 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo, DebriefingS
 	_txtAmountDestination->setWordWrap(true);
 
 	_lstItems->setArrowColumn(193, ARROW_VERTICAL);
-	_lstItems->setColumns(4, 162, 58, 40, 27);
+//	_lstItems->setColumns(4, 162, 58, 40, 27);
+	_lstItems->setColumns(4, 162, 20, 58, 42, 5);
+	_lstItems->setAlign(ALIGN_RIGHT, 1);
+	_lstItems->setAlign(ALIGN_RIGHT, 2);
+	_lstItems->setAlign(ALIGN_RIGHT, 3);
 	_lstItems->setSelectable(true);
 	_lstItems->setBackground(_window);
 	_lstItems->setMargin(2);

--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -108,13 +108,13 @@ DebriefingState::DebriefingState() :
 	_btnTransfer = new TextButton(80, 12, 88, 180);
 	_txtTitle = new Text(300, 17, 16, 8);
 	_txtItem = new Text(180, 9, 16, 24);
-	_txtQuantity = new Text(60, 9, 200, 24);
-	_txtScore = new Text(55, 9, 270, 24);
+	_txtQuantity = new Text(50, 9, 204, 24);
+	_txtScore = new Text(50, 9, 254, 24);
 	_txtRecovery = new Text(180, 9, 16, 60);
 	_txtRating = new Text(200, 9, 64, 180);
-	_lstStats = new TextList(290, 80, 16, 32);
-	_lstRecovery = new TextList(290, 80, 16, 32);
-	_lstTotal = new TextList(290, 9, 16, 12);
+	_lstStats = new TextList(288, 80, 16, 32);
+	_lstRecovery = new TextList(288, 80, 16, 32);
+	_lstTotal = new TextList(288, 9, 16, 12);
 
 	// Second page (soldier stats)
 	_txtSoldier     = new Text(90, 9,  16, 24); //16..106 = 90
@@ -135,7 +135,7 @@ DebriefingState::DebriefingState() :
 	_txtTooltip = new Text(200, 9, 64, 180);
 
 	// Third page (recovered items)
-	_lstRecoveredItems = new TextList(272, 144, 16, 32); // 18 rows
+	_lstRecoveredItems = new TextList(288, 144, 16, 32); // 18 rows
 
 	applyVisibility();
 
@@ -201,74 +201,83 @@ DebriefingState::DebriefingState() :
 	_txtQuantity->setAlign(ALIGN_RIGHT);
 
 	_txtScore->setText(tr("STR_SCORE"));
+	_txtScore->setAlign(ALIGN_RIGHT);
 
-	_lstStats->setColumns(3, 224, 30, 64);
+//	_lstStats->setColumns(3, 224, 30, 64);
+	_lstStats->setColumns(3, 188, 50, 50);
+	_lstStats->setAlign(ALIGN_RIGHT, 1);
+	_lstStats->setAlign(ALIGN_RIGHT, 2);
 	_lstStats->setDot(true);
 
-	_lstRecovery->setColumns(3, 224, 30, 64);
+//	_lstRecovery->setColumns(3, 224, 30, 64);
+	_lstRecovery->setColumns(3, 188, 50, 50);
+	_lstRecovery->setAlign(ALIGN_RIGHT, 1);
+	_lstRecovery->setAlign(ALIGN_RIGHT, 2);
 	_lstRecovery->setDot(true);
 
-	_lstTotal->setColumns(2, 254, 64);
+//	_lstTotal->setColumns(2, 254, 64);
+	_lstTotal->setColumns(2, 238, 50);
+	_lstTotal->setAlign(ALIGN_RIGHT, 1);
 	_lstTotal->setDot(true);
 
 	// Second page
 	_txtSoldier->setText(tr("STR_NAME_UC"));
 
-	_txtTU->setAlign(ALIGN_CENTER);
+	_txtTU->setAlign(ALIGN_RIGHT);
 	_txtTU->setText(tr("STR_TIME_UNITS_ABBREVIATION"));
 	_txtTU->setTooltip("STR_TIME_UNITS");
 	_txtTU->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtTU->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtStamina->setAlign(ALIGN_CENTER);
+	_txtStamina->setAlign(ALIGN_RIGHT);
 	_txtStamina->setText(tr("STR_STAMINA_ABBREVIATION"));
 	_txtStamina->setTooltip("STR_STAMINA");
 	_txtStamina->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtStamina->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtHealth->setAlign(ALIGN_CENTER);
+	_txtHealth->setAlign(ALIGN_RIGHT);
 	_txtHealth->setText(tr("STR_HEALTH_ABBREVIATION"));
 	_txtHealth->setTooltip("STR_HEALTH");
 	_txtHealth->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtHealth->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtBravery->setAlign(ALIGN_CENTER);
+	_txtBravery->setAlign(ALIGN_RIGHT);
 	_txtBravery->setText(tr("STR_BRAVERY_ABBREVIATION"));
 	_txtBravery->setTooltip("STR_BRAVERY");
 	_txtBravery->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtBravery->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtReactions->setAlign(ALIGN_CENTER);
+	_txtReactions->setAlign(ALIGN_RIGHT);
 	_txtReactions->setText(tr("STR_REACTIONS_ABBREVIATION"));
 	_txtReactions->setTooltip("STR_REACTIONS");
 	_txtReactions->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtReactions->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtFiring->setAlign(ALIGN_CENTER);
+	_txtFiring->setAlign(ALIGN_RIGHT);
 	_txtFiring->setText(tr("STR_FIRING_ACCURACY_ABBREVIATION"));
 	_txtFiring->setTooltip("STR_FIRING_ACCURACY");
 	_txtFiring->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtFiring->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtThrowing->setAlign(ALIGN_CENTER);
+	_txtThrowing->setAlign(ALIGN_RIGHT);
 	_txtThrowing->setText(tr("STR_THROWING_ACCURACY_ABBREVIATION"));
 	_txtThrowing->setTooltip("STR_THROWING_ACCURACY");
 	_txtThrowing->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtThrowing->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtMelee->setAlign(ALIGN_CENTER);
+	_txtMelee->setAlign(ALIGN_RIGHT);
 	_txtMelee->setText(tr("STR_MELEE_ACCURACY_ABBREVIATION"));
 	_txtMelee->setTooltip("STR_MELEE_ACCURACY");
 	_txtMelee->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtMelee->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtStrength->setAlign(ALIGN_CENTER);
+	_txtStrength->setAlign(ALIGN_RIGHT);
 	_txtStrength->setText(tr("STR_STRENGTH_ABBREVIATION"));
 	_txtStrength->setTooltip("STR_STRENGTH");
 	_txtStrength->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtStrength->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtPsiStrength->setAlign(ALIGN_CENTER);
+	_txtPsiStrength->setAlign(ALIGN_RIGHT);
 	if (_game->getMod()->isManaFeatureEnabled())
 	{
 		_txtPsiStrength->setText(tr("STR_MANA_ABBREVIATION"));
@@ -282,20 +291,20 @@ DebriefingState::DebriefingState() :
 	_txtPsiStrength->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtPsiStrength->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
-	_txtPsiSkill->setAlign(ALIGN_CENTER);
+	_txtPsiSkill->setAlign(ALIGN_RIGHT);
 	_txtPsiSkill->setText(tr("STR_PSIONIC_SKILL_ABBREVIATION"));
 	_txtPsiSkill->setTooltip("STR_PSIONIC_SKILL");
 	_txtPsiSkill->onMouseIn((ActionHandler)&DebriefingState::txtTooltipIn);
 	_txtPsiSkill->onMouseOut((ActionHandler)&DebriefingState::txtTooltipOut);
 
 	_lstSoldierStats->setColumns(13, 90, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 0);
-	_lstSoldierStats->setAlign(ALIGN_CENTER);
+	_lstSoldierStats->setAlign(ALIGN_RIGHT);
 	_lstSoldierStats->setAlign(ALIGN_LEFT, 0);
 	_lstSoldierStats->setDot(true);
 
 	// Third page
-	_lstRecoveredItems->setColumns(2, 254, 18);
-	_lstRecoveredItems->setAlign(ALIGN_LEFT);
+	_lstRecoveredItems->setColumns(2, 238, 50);
+	_lstRecoveredItems->setAlign(ALIGN_RIGHT, 1);
 	_lstRecoveredItems->setDot(true);
 }
 

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -222,7 +222,7 @@ void create()
 
 	// AI
 	_info.push_back(OptionInfo("brutalAI", &brutalAI, true, "STR_BRUTALAI", "STR_AI"));
-	_info.push_back(OptionInfo("aiPreset", &aiPreset, 4, "STR_AIPRESET", "STR_AI"));
+	_info.push_back(OptionInfo("aiPreset", &aiPreset, 3, "STR_AIPRESET", "STR_AI"));
 	_info.push_back(OptionInfo("brutalCivilians", &brutalCivilians, false, "STR_BRUTALCIVILIANS", "STR_AI"));
 	_info.push_back(OptionInfo("brutalBrutes", &brutalBrutes, true, "STR_BRUTALBRUTES", "STR_AI"));
 	_info.push_back(OptionInfo("ignoreDelay", &ignoreDelay, true, "STR_IGNOREDELAY", "STR_AI"));
@@ -230,10 +230,10 @@ void create()
 	_info.push_back(OptionInfo("allowPreprime", &allowPreprime, true, "STR_ALLOWPREPRIME", "STR_AI"));
 	_info.push_back(OptionInfo("avoidMines", &avoidMines, true, "STR_AVOIDMINES", "STR_AI"));
 	_info.push_back(OptionInfo("avoidCuddle", &avoidCuddle, true, "STR_AVOIDCUDDLE", "STR_AI"));
-	_info.push_back(OptionInfo("randomFactor", &randomFactor, true, "STR_RANDOMFACTOR", "STR_AI"));
+	_info.push_back(OptionInfo("randomFactor", &randomFactor, false, "STR_RANDOMFACTOR", "STR_AI"));
 	_info.push_back(OptionInfo("aiPeformance", &aiPerformanceOptimization, false, "STR_AI_PERFORMANCE", "STR_AI"));
 	_info.push_back(OptionInfo("aiTargetMode", &aiTargetMode, 3, "STR_AITARGETMODE", "STR_AI"));
-	_info.push_back(OptionInfo("aggressionMode", &aggressionMode, 1, "STR_AGGRESSIONMODE", "STR_AI"));
+	_info.push_back(OptionInfo("aggressionMode", &aggressionMode, 0, "STR_AGGRESSIONMODE", "STR_AI"));
 	_info.push_back(OptionInfo("aiAggression", &aiAggression, 2, "STR_AIAGGRESSION", "STR_AI"));
 	_info.push_back(OptionInfo("intelligenceMode", &intelligenceMode, 0, "STR_INTELLIGENCEMODE", "STR_AI"));
 	_info.push_back(OptionInfo("intelligence", &intelligence, 5, "STR_INTELLIGENCE", "STR_AI"));

--- a/src/Geoscape/FundingState.cpp
+++ b/src/Geoscape/FundingState.cpp
@@ -46,10 +46,10 @@ FundingState::FundingState()
 	_window = new Window(this, 320, 200, 0, 0, POPUP_BOTH);
 	_btnOk = new TextButton(50, 12, 135, 180);
 	_txtTitle = new Text(320, 17, 0, 8);
-	_txtCountry = new Text(100, 9, 32, 30);
-	_txtFunding = new Text(100, 9, 140, 30);
-	_txtChange = new Text(72, 9, 240, 30);
-	_lstCountries = new TextList(260, 136, 32, 40);
+	_txtCountry = new Text(100, 9, 30, 30);
+	_txtFunding = new Text(60, 9, 130, 30);
+	_txtChange = new Text(100, 9, 190, 30);
+	_lstCountries = new TextList(260, 136, 30, 40);
 
 	// Set palette
 	setInterface("fundingWindow");
@@ -80,10 +80,15 @@ FundingState::FundingState()
 	_txtCountry->setText(tr("STR_COUNTRY"));
 
 	_txtFunding->setText(tr("STR_FUNDING"));
+	_txtFunding->setAlign(ALIGN_RIGHT);
 
 	_txtChange->setText(tr("STR_CHANGE"));
+	_txtChange->setAlign(ALIGN_RIGHT);
 
-	_lstCountries->setColumns(3, 108, 100, 52);
+	//	_lstCountries->setColumns(3, 108, 100, 52);
+	_lstCountries->setColumns(3, 100, 60, 100);
+	_lstCountries->setAlign(ALIGN_RIGHT, 1);
+	_lstCountries->setAlign(ALIGN_RIGHT, 2);
 	_lstCountries->setDot(true);
 	for (auto* country : *_game->getSavedGame()->getCountries())
 	{

--- a/src/Interface/TextList.cpp
+++ b/src/Interface/TextList.cpp
@@ -344,7 +344,7 @@ void TextList::addRow(int cols, ...)
 		rowHeight = std::max(rowHeight, txt->getTextHeight() + vmargin);
 
 		// Places dots between text
-		if (_dot && i < cols - 1 && (!_dotFirstColumn || i == 0))
+		if (_dot && (!_dotFirstColumn || i == 0))
 		{
 			std::string buf = txt->getText();
 			unsigned int w = txt->getTextWidth();
@@ -352,13 +352,15 @@ void TextList::addRow(int cols, ...)
 			{
 				if (_align[i] != ALIGN_RIGHT)
 				{
-					w += _font->getChar('.').getCrop()->w + _font->getSpacing();
-					buf += '.';
+					char fillChar = (i < cols - 1 ? '.' : ' ');
+					w += _font->getChar(fillChar).getCrop()->w + _font->getSpacing();
+					buf += fillChar;
 				}
 				if (_align[i] != ALIGN_LEFT)
 				{
-					w += _font->getChar('.').getCrop()->w + _font->getSpacing();
-					buf.insert(0, 1, '.');
+					char fillChar = (i > 0 ? '.' : ' ');
+					w += _font->getChar(fillChar).getCrop()->w + _font->getSpacing();
+					buf.insert(0, 1, fillChar);
 				}
 			}
 			txt->setText(buf);


### PR DESCRIPTION
Modified lists:
* Craft inventory
* Research
* Monthly costs
* Purchase
* Sell
* Stores
* Transfer
* Debriefing
* Funding

Didn't bother with smaller list and OCXE based ones (mods, options, etc.). Let me know if you want to change something else. It is not a problem, just tedious to track them all.