### PR TITLE
grenade key

### DIFF
--- a/bin/common/Language/en-US.yml
+++ b/bin/common/Language/en-US.yml
@@ -500,3 +500,5 @@ en-US:
   STR_DISPLAY_BASE_DEFENSE_PROBABILITY_DESC: "Display base defense probability of destroying largests UFO instead of strength in base info screen."
   STR_DISPLAY_BASE_DETECTION_PROBABILITY: "Display base detection probability"
   STR_DISPLAY_BASE_DETECTION_PROBABILITY_DESC: "Display base detection probability instead facility count in base info screen."
+  STR_NO_ITEM: "No item."
+

--- a/bin/standard/xcom1/Language/en-US.yml
+++ b/bin/standard/xcom1/Language/en-US.yml
@@ -1089,3 +1089,7 @@ en-US:
   SECTOPOD_WEAPON: "Sectopod Weapon"
   ZOMBIE_WEAPON: "Zombie Weapon"
   ALIEN_PSI_WEAPON: "Alien Psi Weapon"
+  STR_PRIME_FLARE: "Pick flare"
+  STR_PRIME_SMOKE_GRENADE: "Pick and prime smoke grenade"
+  STR_PRIME_GRENADE: "Pick and prime grenade"
+

--- a/bin/standard/xcom2/Language/en-US.yml
+++ b/bin/standard/xcom2/Language/en-US.yml
@@ -1230,3 +1230,7 @@ en-US:
   TENTACULAT_WEAPON: "Tentaculat Weapon"
   ZOMBIE_WEAPON: "Zombie Weapon"
   ALIEN_PSI_WEAPON: "Alien M.C. Weapon"
+  STR_PRIME_FLARE: "Pick flare"
+  STR_PRIME_SMOKE_GRENADE: "Pick and prime dye grenade"
+  STR_PRIME_GRENADE: "Pick and prime grenade"
+

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -19,6 +19,7 @@
  */
 #include "../Engine/State.h"
 #include "Position.h"
+#include "../Mod/RuleItem.h"
 
 #include <vector>
 #include <string>
@@ -291,6 +292,13 @@ public:
 	
 	/// Handler for clicking the AI button.
 	void btnAIClick(Action *action);
+
+	/// Primes grenade (flair, smoke, regular).
+	void primeFlare(Action* action);
+	void primeSmokeGrenade(Action* action);
+	void primeGrenade(Action* action);
+	void primeAnyGrenade(BattleType battleType, ItemDamageType damageType);
+
 };
 
 }

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -293,11 +293,19 @@ public:
 	/// Handler for clicking the AI button.
 	void btnAIClick(Action *action);
 
-	/// Primes grenade (flair, smoke, regular).
-	void primeFlare(Action* action);
-	void primeSmokeGrenade(Action* action);
-	void primeGrenade(Action* action);
-	void primeAnyGrenade(BattleType battleType, ItemDamageType damageType);
+	/// Ready grenades
+	void readyLightGrenade(Action* action);
+	void readyHeavyGrenade(Action* action);
+	void readyProximityGrenade(Action* action);
+	void readySmokeGrenade(Action* action);
+	void readyFlare(Action* action);
+	void readyScanner(Action* action);
+	void readyMedikit(Action* action);
+	void clearLeftHand(Action* action);
+	void readyItem(BattleType battleType, ItemDamageType itemDamageType = DT_NONE, int minSelectWeight = 0, int maxSelectWeight = 0);
+	void takeItem(BattleItem* selectedItem);
+	void putItem();
+	void primeItem();
 
 };
 

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -465,9 +465,14 @@ void create()
 	_info.push_back(OptionInfo("baseDetectionProbability", &baseDetectionProbability, false, "STR_DISPLAY_BASE_DETECTION_PROBABILITY", "STR_GEOSCAPE"));
 
 	// prime grenades
-	_info.push_back(OptionInfo("keyPrimeFlare", &keyPrimeFlare, SDLK_SLASH, "STR_PRIME_FLARE", "STR_BATTLESCAPE"));
-	_info.push_back(OptionInfo("keyPrimeSmokeGrenade", &keyPrimeSmokeGrenade, SDLK_PERIOD, "STR_PRIME_SMOKE_GRENADE", "STR_BATTLESCAPE"));
-	_info.push_back(OptionInfo("keyPrimeGrenade", &keyPrimeGrenade, SDLK_COMMA, "STR_PRIME_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyLightGrenade", &keyReadyLightGrenade, SDLK_COMMA, "STR_KEY_READY_LIGHT_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyHeavyGrenade", &keyReadyHeavyGrenade, SDLK_PERIOD, "STR_KEY_READY_HEAVY_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyProximityGrenade", &keyReadyProximityGrenade, SDLK_SLASH, "STR_KEY_READY_PROXIMITY_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadySmokeGrenade", &keyReadySmokeGrenade, SDLK_SEMICOLON, "STR_KEY_READY_SMOKE_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyFlare", &keyReadyFlare, SDLK_QUOTE, "STR_KEY_READY_FLARE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyScanner", &keyReadyScanner, SDLK_RIGHTBRACKET, "STR_KEY_READY_SCANNER", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyReadyMedikit", &keyReadyMedikit, SDLK_LEFTBRACKET, "STR_KEY_READY_MEDIKIT", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyClearLeftHand", &keyClearLeftHand, SDLK_MINUS, "STR_KEY_CLEAR_LEFT_HAND", "STR_BATTLESCAPE"));
 
 }
 

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -464,6 +464,11 @@ void create()
 	// display base detection probability in base info screen
 	_info.push_back(OptionInfo("baseDetectionProbability", &baseDetectionProbability, false, "STR_DISPLAY_BASE_DETECTION_PROBABILITY", "STR_GEOSCAPE"));
 
+	// prime grenades
+	_info.push_back(OptionInfo("keyPrimeFlare", &keyPrimeFlare, SDLK_SLASH, "STR_PRIME_FLARE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyPrimeSmokeGrenade", &keyPrimeSmokeGrenade, SDLK_PERIOD, "STR_PRIME_SMOKE_GRENADE", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("keyPrimeGrenade", &keyPrimeGrenade, SDLK_COMMA, "STR_PRIME_GRENADE", "STR_BATTLESCAPE"));
+
 }
 
 // we can get fancier with these detection routines, but for now just look for

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -156,3 +156,8 @@ OPT bool baseDefenseProbability;
 // display base detection probability in base info screen
 OPT bool baseDetectionProbability;
 
+// prime grenades
+OPT SDLKey keyPrimeFlare;
+OPT SDLKey keyPrimeSmokeGrenade;
+OPT SDLKey keyPrimeGrenade;
+

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -157,7 +157,12 @@ OPT bool baseDefenseProbability;
 OPT bool baseDetectionProbability;
 
 // prime grenades
-OPT SDLKey keyPrimeFlare;
-OPT SDLKey keyPrimeSmokeGrenade;
-OPT SDLKey keyPrimeGrenade;
+OPT SDLKey keyReadyLightGrenade;
+OPT SDLKey keyReadyHeavyGrenade;
+OPT SDLKey keyReadyProximityGrenade;
+OPT SDLKey keyReadySmokeGrenade;
+OPT SDLKey keyReadyFlare;
+OPT SDLKey keyReadyScanner;
+OPT SDLKey keyReadyMedikit;
+OPT SDLKey keyClearLeftHand;
 

--- a/src/OpenXcom.2010.vcxproj.user
+++ b/src/OpenXcom.2010.vcxproj.user
@@ -21,6 +21,6 @@
     <LocalDebuggerCommandArguments>-data "$(ProjectDir)..\bin"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
+    <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
 </Project>

--- a/src/OpenXcom.2010.vcxproj.user
+++ b/src/OpenXcom.2010.vcxproj.user
@@ -21,6 +21,6 @@
     <LocalDebuggerCommandArguments>-data "$(ProjectDir)..\bin"</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <ShowAllFiles>false</ShowAllFiles>
+    <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is just QoL thing I have created for myself. See if you are interested in merging this. No biggie if not.

Added few keys to automatically find, pick, prime different items: grenades, flares, smoke grenades, high explosive, medikit, scanner without getting into inventory.
All these thing those are repeated over and over again: open inventory, move items, get out of the inventory, prime grenade, etc.

They are hooked on unused keys. So player is not obligated to use them, of course.