### PR TITLE
 Autocombat per unit control: UI for controlling aggresiveness per unit 

### DIFF
--- a/src/Basescape/SoldiersAIState.cpp
+++ b/src/Basescape/SoldiersAIState.cpp
@@ -83,10 +83,16 @@ void SoldiersAIState::_commonConstruct()
 	_window = new Window(this, 320, 200, 0, 0);
 	_btnOk = new TextButton(148, 16, 164, 176);
 	_txtTitle = new Text(300, 17, 16, 7);
-	_txtName = new Text(114, 9, 16, 32);
-	_txtRank = new Text(102, 9, 122, 32);
-	_txtControlled = new Text(84, 9, 220, 32);
-	_lstSoldiers = new TextList(288, 128, 8, 40);
+	_lstUnits = new TextList(288, 128, 8, 40);
+	// list column headers
+	constexpr int gap = 4; //TODO adjust?
+	int xoff = 16;
+	static constexpr int cWidths[] = {110, 80, 76};
+	_txtName = new Text(cWidths[0], 9, xoff, 32);
+	xoff += cWidths[0] + gap;
+	_txtRank = new Text(cWidths[1], 9, xoff, 32);
+	xoff += cWidths[1] + gap;
+	_txtControlled = new Text(cWidths[2], 9, xoff, 32);
 
 	// Set palette
 	setInterface("craftSoldiers");
@@ -97,7 +103,7 @@ void SoldiersAIState::_commonConstruct()
 	add(_txtName, "text", "craftSoldiers");
 	add(_txtRank, "text", "craftSoldiers");
 	add(_txtControlled, "text", "craftSoldiers");
-	add(_lstSoldiers, "list", "craftSoldiers");
+	add(_lstUnits, "list", "craftSoldiers");
 
 	centerAllSurfaces();
 
@@ -117,13 +123,13 @@ void SoldiersAIState::_commonConstruct()
 
 	_txtControlled->setText(tr("STR_AI_CONTROLLED"));
 
-	_lstSoldiers->setArrowColumn(188, ARROW_VERTICAL);
-	_lstSoldiers->setColumns(3, 106, 98, 76);
-	_lstSoldiers->setAlign(ALIGN_RIGHT, 3);
-	_lstSoldiers->setSelectable(true);
-	_lstSoldiers->setBackground(_window);
-	_lstSoldiers->setMargin(8);
-	_lstSoldiers->onMouseClick((ActionHandler)&SoldiersAIState::lstSoldiersClick, 0);
+	//_lstUnits->setArrowColumn(188, ARROW_VERTICAL);	//Input mostly temporary vector, so reordering not persistent. Disable completly
+	_lstUnits->setColumns(noCol, cWidths[0], cWidths[1], cWidths[2]);	//TODO with or without gap?
+	_lstUnits->setAlign(ALIGN_RIGHT, 3);
+	_lstUnits->setSelectable(true);
+	_lstUnits->setBackground(_window);
+	_lstUnits->setMargin(8);
+	_lstUnits->onMouseClick((ActionHandler)&SoldiersAIState::lstSoldiersClick, 0);
 }
 
 /**
@@ -148,27 +154,25 @@ void SoldiersAIState::btnOkClick(Action *)
  */
 void SoldiersAIState::initList(size_t scrl)
 {
-	_lstSoldiers->clearList();
-
-	_lstSoldiers->setColumns(3, 106, 98, 76);
+	_lstUnits->clearList();
 
 	std::vector<bool> allows;
 	if (!_soldiers.empty())
 	{
-		for (const auto* soldier : _soldiers)
+		for (const auto* s : _soldiers)
 		{
-			_lstSoldiers->addRow(3, soldier->getName(true, 19).c_str(), tr(soldier->getRankString()).c_str(), "");
-			allows.emplace_back(soldier->getAllowAutoCombat());
+			_lstUnits->addRow(noCol, s->getName(true, 19).c_str(), tr(s->getRankString()).c_str(), "");
+			allows.emplace_back(s->getAllowAutoCombat());
 		}
 	}
 	else
 	{
-		for (const auto* unit : _units)
+		for (const auto* u : _units)
 		{
-			const std::string name = unit->getGeoscapeSoldier() ? unit->getGeoscapeSoldier()->getName(true, 19) : unit->getName(_game->getLanguage());	//BattleUnit::getName has no maxLength parameter. Default value might change and Statstring might be way to long.
-			const std::string rank = unit->getRankString();
-			_lstSoldiers->addRow(3, name.c_str(), tr(rank).c_str(), "");
-			allows.emplace_back(unit->getAllowAutoCombat());
+			const std::string name = u->getGeoscapeSoldier() ? u->getGeoscapeSoldier()->getName(true, 19) : u->getName(_game->getLanguage());	//BattleUnit::getName has no maxLength parameter. Default value might change and Statstring might be way to long.
+			const std::string rank = u->getRankString();
+			_lstUnits->addRow(noCol, name.c_str(), tr(rank).c_str(), "");
+			allows.emplace_back(u->getAllowAutoCombat());
 		}
 	}
 	
@@ -177,20 +181,20 @@ void SoldiersAIState::initList(size_t scrl)
 		Uint8 color;
 		if (allows[row])
 		{
-			color = _lstSoldiers->getSecondaryColor();
-			_lstSoldiers->setCellText(row, 2, tr("True"));
+			color = _lstUnits->getSecondaryColor();
+			_lstUnits->setCellText(row, 2, tr("True"));
 		}
 		else
 		{
-			color = _lstSoldiers->getColor();
-			_lstSoldiers->setCellText(row, 2, tr("False"));
+			color = _lstUnits->getColor();
+			_lstUnits->setCellText(row, 2, tr("False"));
 		}
-		_lstSoldiers->setRowColor(row, color);
+		_lstUnits->setRowColor(row, color);
 	}
 	
 	if (scrl)
-		_lstSoldiers->scrollTo(scrl);
-	_lstSoldiers->draw();
+		_lstUnits->scrollTo(scrl);
+	_lstUnits->draw();
 }
 
 /**
@@ -209,38 +213,38 @@ void SoldiersAIState::init()
 void SoldiersAIState::lstSoldiersClick(Action *action)
 {
 	double mx = action->getAbsoluteXMouse();
-	if (mx >= _lstSoldiers->getArrowsLeftEdge() && mx < _lstSoldiers->getArrowsRightEdge())
+	if (mx >= _lstUnits->getArrowsLeftEdge() && mx < _lstUnits->getArrowsRightEdge())
 	{
 		return;
 	}
-	int row = _lstSoldiers->getSelectedRow();
+	int row = _lstUnits->getSelectedRow();
 	if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
 	{
 		const bool newAI = _soldiers.empty() ? toggleAIBattleUnit() : toggleAISoldier();
-		Uint8 color = _lstSoldiers->getColor();
+		Uint8 color = _lstUnits->getColor();
 		if (newAI)
 		{
-			color = _lstSoldiers->getSecondaryColor();
-			_lstSoldiers->setCellText(row, 2, tr("True"));
+			color = _lstUnits->getSecondaryColor();
+			_lstUnits->setCellText(row, 2, tr("True"));
 		}
 		else
 		{
-			_lstSoldiers->setCellText(row, 2, tr("False"));
+			_lstUnits->setCellText(row, 2, tr("False"));
 		}
-		_lstSoldiers->setRowColor(row, color);
+		_lstUnits->setRowColor(row, color);
 	}
 }
 
 
 bool SoldiersAIState::toggleAISoldier()
 {
-	Soldier *s = _soldiers.at(_lstSoldiers->getSelectedRow());
+	Soldier *s = _soldiers.at(_lstUnits->getSelectedRow());
 	return s->toggleAllowAutoCombat();
 }
 
 bool SoldiersAIState::toggleAIBattleUnit()
 {
-	auto* bu = _units.at(_lstSoldiers->getSelectedRow());
+	auto* bu = _units.at(_lstUnits->getSelectedRow());
 	return bu->toggleAllowAutoCombat();
 }
 

--- a/src/Basescape/SoldiersAIState.h
+++ b/src/Basescape/SoldiersAIState.h
@@ -41,12 +41,12 @@ struct SortFunctor;
 class SoldiersAIState : public State
 {
 private:
-	static constexpr int noCol = 3;	//Name Rank AI-Control
+	static constexpr int noCol = 4;	//Name Rank AI-Control Aggresiveness
 
 	TextButton *_btnOk;
 	Window *_window;
 	Text *_txtTitle, *_txtName, *_txtRank;
-	Text *_txtControlled;
+	Text *_txtControlled, *_txtAgressiveness;
 	TextList *_lstUnits;
 
 	std::vector<Soldier *> _soldiers;
@@ -80,6 +80,15 @@ public:
 	bool toggleAISoldier();
 	/// Toggle AI control @ autocombat of currently selected battleunit
 	bool toggleAIBattleUnit();
+
+	/// Toggle AI aggressiveness @ autocombat of currently selected soldier/battleunit
+	<template typename T>
+	int toggleAgg(T* unit)
+	{
+		const auto newVal = (T->getAggression() + 1) % TODO_MAX_VALUE;
+		T->setAggression(newVal);
+		return newVal;
+	}
 };
 
 }

--- a/src/Basescape/SoldiersAIState.h
+++ b/src/Basescape/SoldiersAIState.h
@@ -35,43 +35,45 @@ class Soldier;
 struct SortFunctor;
 
 /**
- * Select Squad screen that lets the player
- * pick the soldiers to be controlled by AI.
+ * Screen that lets the player
+ * control the AI parameters for soldiers/battleunits.
  */
 class SoldiersAIState : public State
 {
 private:
+	static constexpr int noCol = 3;	//Name Rank AI-Control
+
 	TextButton *_btnOk;
 	Window *_window;
 	Text *_txtTitle, *_txtName, *_txtRank;
 	Text *_txtControlled;
-	TextList *_lstSoldiers;
+	TextList *_lstUnits;
 
 	std::vector<Soldier *> _soldiers;
 	std::vector<BattleUnit *> _units;
-	/// initializes the display list based on the soldiers given in the constructor
+	/// initializes the display list based on the units given in the constructor
 	void initList(size_t scrl);
 	/// Proxy for constructor
 	void _commonConstruct();
 public:
-	/// Creates the Soldiers AI state.
+	/// Creates the Unit AI state.
 	SoldiersAIState(std::vector<Soldier*>& soldiers);
 	SoldiersAIState(const Craft* craft);
-	/// Creates the Soldiers AI state in Battle.
+	/// Creates the Unit AI state in Battle.
 	SoldiersAIState(std::vector<BattleUnit*>& units);
-	/// Cleans up the Soldiers AI state.
+	/// Cleans up the Unit AI state.
 	~SoldiersAIState();
 	/// Handler for clicking the OK button.
 	void btnOkClick(Action *action);
 	/// Handler for clicking the Preview button.
 	void btnPreviewClick(Action *action);
-	/// Updates the soldiers list.
+	/// Updates the unit list.
 	void init() override;
-	/// Moves a soldier up.
+	/// Moves a unit up.
 	void moveSoldierUp(Action *action, unsigned int row, bool max = false);
-	/// Moves a soldier down.
+	/// Moves a unit down.
 	void moveSoldierDown(Action *action, unsigned int row, bool max = false);
-	/// Handler for clicking the Soldiers list.
+	/// Handler for clicking the Unit list.
 	void lstSoldiersClick(Action *action);
 
 	/// Toggle AI control @ autocombat of currently selected soldier

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -82,7 +82,7 @@ BattleUnit::BattleUnit(const Mod *mod, Soldier *soldier, int depth, const RuleSt
 	_rank = soldier->getRankString();
 	_gender = soldier->getGender();
 	_intelligence = 2;
-	_aggression = 1;
+	_aggression = soldier->getAggression();
 	_faceDirection = -1;
 	_floorAbove = false;
 	_breathing = false;
@@ -716,6 +716,7 @@ void BattleUnit::load(const YAML::Node &node, const Mod *mod, const ScriptGlobal
 	_meleeAttackedBy = node["meleeAttackedBy"].as<std::vector<int> >(_meleeAttackedBy);
 
 	_allowAutoCombat = node["allowAutoCombat"].as<bool>(_allowAutoCombat);
+	_aggression = node["aggression"].as<bool>(_aggression);
 
 	_scriptValues.load(node, shared);
 }
@@ -878,6 +879,7 @@ YAML::Node BattleUnit::save(const ScriptGlobal *shared) const
 	}
 
 	node["allowAutoCombat"] = _allowAutoCombat;
+	node["aggression"] = _aggression;
 
 	_scriptValues.save(node, shared);
 
@@ -4567,6 +4569,15 @@ int BattleUnit::getIntelligence() const
 int BattleUnit::getAggression() const
 {
 	return _aggression;
+}
+
+/**
+ * Set the unit's aggression.
+ * @param aggression.
+ */
+void BattleUnit::setAggression(int aggression)
+{
+	_aggression = aggression;
 }
 
 int BattleUnit::getMaxViewDistance(int baseVisibility, int nerf, int buff) const

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -616,6 +616,8 @@ public:
 	int getIntelligence() const;
 	/// Get the unit's aggression.
 	int getAggression() const;
+	/// Set the unit's aggression.
+	void setAggression(int aggression);
 	/// Helper method.
 	int getMaxViewDistance(int baseVisibility, int nerf, int buff) const;
 	/// Get maximum view distance at dark.

--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -55,7 +55,8 @@ Soldier::Soldier(RuleSoldier *rules, Armor *armor, int nationality, int id) :
 	_gender(GENDER_MALE), _look(LOOK_BLONDE), _lookVariant(0), _missions(0), _kills(0), _stuns(0),
 	_recentlyPromoted(false), _psiTraining(false), _training(false), _returnToTrainingWhenHealed(false),
 	_armor(armor), _replacedArmor(0), _transformedArmor(0), _personalEquipmentArmor(nullptr), _death(0), _diary(new SoldierDiary()),
-	_corpseRecovered(false)
+	_corpseRecovered(false),
+	_allowAutoCombat(Options::autoCombatDefaultSoldier), _aggression(TODODefaultValue-Or-Option::VALUE)
 {
 	if (id != 0)
 	{
@@ -121,8 +122,6 @@ Soldier::Soldier(RuleSoldier *rules, Armor *armor, int nationality, int id) :
 		}
 	}
 	_lookVariant = RNG::seedless(0, RuleSoldier::LookVariantMax - 1);
-
-	_allowAutoCombat = Options::autoCombatDefaultSoldier;
 }
 
 /**
@@ -193,6 +192,7 @@ void Soldier::load(const YAML::Node& node, const Mod *mod, SavedGame *save, cons
 	_healthMissing = node["healthMissing"].as<int>(_healthMissing);
 	_recovery = node["recovery"].as<float>(_recovery);
 	_allowAutoCombat = node["allowAutoCombat"].as<bool>(_allowAutoCombat);
+	_aggression = node["aggression"].as<bool>(_aggression);
 	Armor *armor = _armor;
 	if (node["armor"])
 	{
@@ -345,6 +345,7 @@ YAML::Node Soldier::save(const ScriptGlobal *shared) const
 		node["transformationBonuses"] = _transformationBonuses;
 
 	node["allowAutoCombat"] = _allowAutoCombat;
+	node["aggression"] = _aggression;
 
 	_scriptValues.save(node, shared);
 

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -77,6 +77,7 @@ private:
 	float _recovery = 0.0;  // amount of hospital attention soldier needs... used to calculate recovery time
 	bool _recentlyPromoted, _psiTraining, _training, _returnToTrainingWhenHealed;
 	bool _allowAutoCombat;
+	int _aggression;
 	Armor *_armor;
 	Armor *_replacedArmor;
 	Armor *_transformedArmor;
@@ -286,6 +287,10 @@ public:
 	void setAllowAutoCombat(const bool newValue) {_allowAutoCombat = newValue;}
 	/// Returns new value
 	bool toggleAllowAutoCombat() {_allowAutoCombat = !_allowAutoCombat; return _allowAutoCombat;}
+	/// Get the unit's aggression.
+	int getAggression() const {return _aggression;}
+	/// Set the unit's aggression.
+	void setAggression(int aggression) {_aggression = aggression;}	
 	/// Gets the previous transformations performed on this soldier
 	std::map<std::string, int> &getPreviousTransformations();
 	/// Returns whether the unit is eligible for a certain transformation


### PR DESCRIPTION
See title.
Modifies the _agression object member of battleunits.
Mind the TODOs (constants unknown to me), the TODOs regarding the look of the window can be ignored for now.