### PR TITLE
Revert "style(BattleUnit::prepareTimeUnits): Slightly lighter syntax"

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -2890,7 +2890,7 @@ void BattleUnit::prepareTimeUnits(int tu)
 			const float encumbrance = static_cast<float>(getBaseStats()->strength) / carried;
 			if (encumbrance < 1.0f)
 			{
-				_tu *= static_cast<int>(std::round(encumbrance));
+				_tu = static_cast<int>(std::round(encumbrance * _tu));
 			}
 		}
 		// Each fatal wound to the left or right leg reduces the soldier's TUs by 10%.


### PR DESCRIPTION
## Purpose and Description
I think the new order (that is being reverted) causes tu calculation logic alteration, which wasn't my intent.
I missed the fact that there is rounding, that took place **after** multiplication, so I'm just reverting to the same order of operation.

This reverts commit 2bf7312781cd4f8784c8986251ab3c5ae6800443.