### PR TITLE
Smoke adds constant density

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -1821,7 +1821,7 @@ std::tuple<int, int, int, int, int> getTrajectoryDataHelper(TileEngine* te, cons
 		visibleDistanceVoxels += step;
 		if (t->getFire() == 0)
 		{
-			densityOfSmoke += step * t->getSmoke();
+			densityOfSmoke += step * 20;
 		}
 		else
 		{


### PR DESCRIPTION
Here is an example how to make smoke producing constant density for the purpose of vision distance regardless of its age/thickness.
Of course, this also can be wrapped into configurable option.