### PR TITLE
fix: RandomWoundType cleanup

### DIFF
--- a/bin/common/Language/Technical/en-US.yml
+++ b/bin/common/Language/Technical/en-US.yml
@@ -56,9 +56,9 @@ en-US:
   DRT_STANDARD: "standard damage range"
   DRT_EXPLOSION: "explosion damage range"
 #
-  WRT_LINEAR: "flat"
-  WRT_VANILLA: "vanilla"
-  WRT_RANDOM: "0-100% spread"
+  WRT_VANILLA: "vanilla formula"
+  WRT_SPREAD: "0-100% spread"
+  WRT_UNSUPPORTED: "unsupported (disabled)"
 #
   BFT_NONE: "none"
   BFT_INSTANT: "instant"

--- a/src/Mod/RuleDamageType.cpp
+++ b/src/Mod/RuleDamageType.cpp
@@ -200,6 +200,7 @@ void RuleDamageType::load(const YAML::YamlNodeReader& node)
 	reader.tryRead("RandomArmor", RandomArmor);
 	reader.tryRead("RandomArmorPre", RandomArmorPre);
 	reader.tryRead("RandomWound", RandomWound);
+	reader.tryRead("RandomWoundType", RandomWoundType);
 	reader.tryRead("RandomItem", RandomItem);
 	reader.tryRead("RandomTile", RandomTile);
 	reader.tryRead("RandomStun", RandomStun);
@@ -287,9 +288,7 @@ int RuleDamageType::getWoundFinalDamage(int damage) const
 					return RNG::generate(1, 3);
 				}
 				break;
-			case ItemWoundRandomType::LINEAR:
-				return woundPotential;
-			case ItemWoundRandomType::RANDOM:
+			case ItemWoundRandomType::SPREAD:
 				return RNG::generate(0, woundPotential);
 			}
 		}

--- a/src/Mod/RuleDamageType.h
+++ b/src/Mod/RuleDamageType.h
@@ -41,8 +41,7 @@ enum ItemDamageRandomType
 enum class ItemWoundRandomType : int
 {
 	VANILLA = 0,
-	LINEAR = 1,
-	RANDOM = 2
+	SPREAD = 1
 };
 
 /**
@@ -116,7 +115,7 @@ struct RuleDamageType
 	bool RandomArmorPre;
 	/// Damage type use random chance for wound number.
 	bool RandomWound;
-	/// Damage type use vanilla wound formula, linear or random conversion.
+	/// Damage type use vanilla wound formula or random conversion.
 	ItemWoundRandomType RandomWoundType;
 	/// Damage type use random conversion item damage.
 	bool RandomItem;

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -1823,17 +1823,14 @@ void StatsForNerdsState::addRandomWoundType(std::ostringstream& ss, const ItemWo
 
 	switch (value)
 	{
-	case ItemWoundRandomType::LINEAR:
-		ss << tr("WRT_LINEAR");
-		break;
 	case ItemWoundRandomType::VANILLA:
 		ss << tr("WRT_VANILLA");
 		break;
-	case ItemWoundRandomType::RANDOM:
-		ss << tr("WRT_RANDOM");
+	case ItemWoundRandomType::SPREAD:
+		ss << tr("WRT_SPREAD");
 		break;
 	default:
-		ss << tr("STR_UNKNOWN");
+		ss << tr("WRT_UNSUPPORTED");
 		break;
 	}
 
@@ -2093,7 +2090,7 @@ void StatsForNerdsState::initItemList()
 
 		addFloatAsPercentage(ss, rule->ToWound, "ToWound", ruleByResistType->ToWound);
 		addBoolean(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
-		addRandomWoundType(ss, rule->RandomWoundType, "RandomWound", ruleByResistType->RandomWoundType);
+		addRandomWoundType(ss, rule->RandomWoundType, "RandomWoundType", ruleByResistType->RandomWoundType);
 
 		addFloatAsPercentage(ss, rule->ToTime, "ToTime", ruleByResistType->ToTime);
 		addBoolean(ss, rule->RandomTime, "RandomTime", ruleByResistType->RandomTime);


### PR DESCRIPTION
### Description
- Remove the unused "linear"/"flat" RandomWoundType. It's no longer needed.
- Add a forgotten deserialization line. Without it, the new `RandomWoundType` wasn't being read from the ruleset.
- Fix the wrong field name for `RandomWoundType` in stats for nerds. It was using `RandomWound` string.
- Rename "Random" mode to "Spread", to be more descriptive.
- Add `WRT_UNSUPPORTED` string to display if a mod uses an unsupported `RandomWoundType` value.
### Tests
Just to be sure, I've tested that xcom files mod loads fine and started a battle just fine. The default wound type is correct.
I've also tested different values to ensure that they work, and unsupported ones don't break the game.
### Important
**If a mod was using `RandomWoundType: 2`, they'll have to update their ruleset with `RandomWoundType: 1`!**
Using unsupported values won't crash the mod, but the wound function will always return 0.