### PR TITLE
Update BattleItem.cpp removing empty clips from the battlescape function update

### DIFF
--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -932,7 +932,7 @@ void BattleItem::spendAmmoForAction(BattleActionType action, SavedBattleGame* sa
 	auto ammo = getAmmoForAction(action, nullptr, &spendPerShot);
 	if (ammo)
 	{
-		if (ammo->getRules()->getClipSize() > 0 && ammo->spendBullet(spendPerShot) == false)
+		if (ammo->getRules()->getClipSize() > 0 && ammo->spendBullet(spendPerShot) == false || _rules->getBattleType() != BT_FIREARM)
 		{
 			save->removeItem(ammo);
 			ammo->setIsAmmo(false);

--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -932,7 +932,7 @@ void BattleItem::spendAmmoForAction(BattleActionType action, SavedBattleGame* sa
 	auto ammo = getAmmoForAction(action, nullptr, &spendPerShot);
 	if (ammo)
 	{
-		if (ammo->getRules()->getClipSize() > 0 && ammo->spendBullet(spendPerShot) == false || _rules->getBattleType() != BT_FIREARM)
+		if (ammo->getRules()->getClipSize() > 0 && ammo->spendBullet(spendPerShot) == false && _rules->getBattleType() != BT_FIREARM)
 		{
 			save->removeItem(ammo);
 			ammo->setIsAmmo(false);


### PR DESCRIPTION
Original game doesn`t allow weapons to disappear when their own ammo depleted.
Let's do the same in OpenX.com.

**For example:** the Sonic Displacer Weapon in TFTD doesn't use a magazine, but has its own ammo (100). When the ammo count reaches 0, the weapon disappears in OpenXCOM and remains in DOS Vanilla.